### PR TITLE
#20 - Add phpunit to project

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ jobs:
 
       - run:
           name: PHPUnit
-          command: ./vendor/bin/phpunit
+          command: ./vendor/bin/simple-phpunit
 
       - save_cache:
           key: cache-v1-{{ checksum "composer.lock" }}


### PR DESCRIPTION
When installing symfony/phpunit-bridge (by @msvrtan, commit 7501e399bd1c58), the phpunit executable is called simple-phpunit. However, CircleCi was looking for executable called 'phpunit' (7501e399bd1c58)
and so build failed.

Closes #26 