### PR TITLE
#45 - Add link to 'login' and 'register' on homepage 

### DIFF
--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -3,15 +3,18 @@
 namespace App\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class HomepageController
 {
-
+    /**
+     * @Template()
+    */
     public function indexAction()
     {
-        return new JsonResponse(['id'=>1,'name'=>'John']);
+//        return new JsonResponse(['id'=>1,'name'=>'John']);
     }
 
     /**

--- a/templates/homepage/index.html.twig
+++ b/templates/homepage/index.html.twig
@@ -1,0 +1,12 @@
+{% extends 'base.html.twig' %}
+    {% block body %}
+        <nav class="navbar navbar-light bg-light">
+          <span class="navbar-text">
+              {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
+                  Hello {{ app.user.username }}
+              {% else %}
+                  Please <a href="{{ path('fos_user_security_login') }}">{{ 'layout.login'|trans({}, 'FOSUserBundle') }}</a> or <a href="{{ path('fos_user_registration_register') }}">{{ 'layout.register'|trans({}, 'FOSUserBundle') }}</a>
+              {% endif %}
+          </span>
+        </nav>
+    {% endblock %}

--- a/tests/Controller/HomepageControllerTest.php
+++ b/tests/Controller/HomepageControllerTest.php
@@ -16,6 +16,7 @@ class HomepageControllerTest extends WebTestCase
 
         $client->request('GET', $url);
 
-        self::assertEquals('{"id":1,"name":"John"}', $client->getResponse()->getContent());
+        $greetMessage = 'Please <a href="/login">Log in</a> or <a href="/register/">Register</a>';
+        self::assertContains($greetMessage, $client->getResponse()->getContent());
     }
 }


### PR DESCRIPTION
This will show links to 'login' and 'register' pages on homepage in case visitor is not logged in.

If user is already logged in, we'll show them a greeting with their username.

Closes #45 