### PR TITLE
#47 - Make CircleCI use migrations

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ jobs:
 
       - run:
           name: Update schema (add all tables project needs)
-          command: php bin/console doctrine:schema:update --force
+          command: php bin/console doctrine:migrations:migrate --no-interaction
 
       - run:
           name: PHPUnit


### PR DESCRIPTION
Now that we're using doctrine migrations, we should use them on CircleCI
as well, instead of running complete schema updates.

Closes #47 