### PR TITLE
Issue #69 - Run php-cs-fixer on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -40,6 +40,10 @@ jobs:
           name: PHPUnit
           command: ./vendor/bin/simple-phpunit
 
+      - run:
+          name: Php-cs-fixer
+          command: php vendor/bin/php-cs-fixer fix -vvv
+          
       - save_cache:
           key: cache-v1-{{ checksum "composer.lock" }}
           paths:

--- a/src/Controller/HomepageController.php
+++ b/src/Controller/HomepageController.php
@@ -11,7 +11,7 @@ class HomepageController
 {
     /**
      * @Template()
-    */
+     */
     public function indexAction()
     {
 //        return new JsonResponse(['id'=>1,'name'=>'John']);

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -16,17 +16,16 @@ class Kernel extends BaseKernel
 
     public function getCacheDir()
     {
-        if (true === in_array($this->environment, ['dev', 'test'])){
-        return '/dev/shm/cache';
+        if (true === in_array($this->environment, ['dev', 'test'])) {
+            return '/dev/shm/cache';
         }
-        return $this->getProjectDir().'/var/cache/'.$this->environment;
 
+        return $this->getProjectDir().'/var/cache/'.$this->environment;
     }
 
     public function getLogDir()
     {
         return $this->getProjectDir().'/var/log';
-
     }
 
     public function registerBundles()

--- a/src/Migrations/Version20180113111523.php
+++ b/src/Migrations/Version20180113111523.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
+
+declare(strict_types=1);
 
 namespace DoctrineMigrations;
 
@@ -13,7 +15,7 @@ class Version20180113111523 extends AbstractMigration
     public function up(Schema $schema)
     {
         // this up() migration is auto-generated, please modify it to your needs
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('CREATE TABLE users (id INT AUTO_INCREMENT NOT NULL, username VARCHAR(180) NOT NULL, username_canonical VARCHAR(180) NOT NULL, email VARCHAR(180) NOT NULL, email_canonical VARCHAR(180) NOT NULL, enabled TINYINT(1) NOT NULL, salt VARCHAR(255) DEFAULT NULL, password VARCHAR(255) NOT NULL, last_login DATETIME DEFAULT NULL, confirmation_token VARCHAR(180) DEFAULT NULL, password_requested_at DATETIME DEFAULT NULL, roles LONGTEXT NOT NULL COMMENT \'(DC2Type:array)\', UNIQUE INDEX UNIQ_1483A5E992FC23A8 (username_canonical), UNIQUE INDEX UNIQ_1483A5E9A0D96FBF (email_canonical), UNIQUE INDEX UNIQ_1483A5E9C05FB297 (confirmation_token), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB');
     }
@@ -21,7 +23,7 @@ class Version20180113111523 extends AbstractMigration
     public function down(Schema $schema)
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
 
         $this->addSql('DROP TABLE users');
     }

--- a/tests/Controller/HomepageControllerTest.php
+++ b/tests/Controller/HomepageControllerTest.php
@@ -3,11 +3,9 @@
 namespace App\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
 class HomepageControllerTest extends WebTestCase
 {
-
     public function testHomepage()
     {
         $url = '/';


### PR DESCRIPTION
In order to have a clean code base with properly formatted code and no coding style violations
As maintainers
We need to make sure code that doesn't meet set criteria doesn't make it into `master` by running checks on CircleCI
As currently we don't have automated checks in place and need to manually check for violations.

Closes #70 