### PR TITLE
Issue #75 - Add a repository class for Post enitity

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -16,7 +16,7 @@ services:
     # this creates a service per class whose id is the fully-qualified class name
     App\:
         resource: '../src/*'
-        exclude: '../src/{Entity,Migrations,Tests}'
+        exclude: '../src/{DataFixtures,Entity,Migrations,Tests}'
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class

--- a/src/DataFixtures/ORM/PostsFixtures.php
+++ b/src/DataFixtures/ORM/PostsFixtures.php
@@ -20,6 +20,9 @@ class PostsFixtures extends AbstractFixture implements OrderedFixtureInterface
         $manager->persist($postOne);
         $manager->persist($postTwo);
 
+        $this->addReference('postOne', $postOne);
+        $this->addReference('postTwo', $postTwo);
+
         $manager->flush();
     }
 

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class PostRepository extends EntityRepository
+{
+}


### PR DESCRIPTION
_In order to have a structured and easy to use way of retrieving Post entities_
_As developers_
_We need to have a repository of Post entities at our disposal._

This PR will add a Post Repository.

Closes #75 