### PR TITLE
Issue #86 - Fix CircleCI command for php-cs-fixer

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -42,7 +42,7 @@ jobs:
 
       - run:
           name: Php-cs-fixer
-          command: php vendor/bin/php-cs-fixer fix -vvv
+          command: php vendor/bin/php-cs-fixer fix --dry-run --diff
           
       - save_cache:
           key: cache-v1-{{ checksum "composer.lock" }}


### PR DESCRIPTION
Previous version of circle.yml ran php-cs-fixer command with wrong
arguments - it was trying to fix the errors in files, instead of just
checking if files were properly formatted.

Executing changes on CircleCI has no effect, as php-cs-fixer returns
exit code 0 when successfully fixing the files.

Closes #86 