### PR TITLE
Add posts scaffolding

### DIFF
--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Controller;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+use App\Entity\Post;
+
+class PostController extends Controller
+{
+    /**
+     * @Route("/posts", name="posts")
+     */
+    public function index()
+    {
+        $posts = $this->getDoctrine()
+            ->getRepository(Post::class)
+            ->findAll();
+
+        return $this->render('post/index.html.twig', ['posts' => $posts]);
+    }
+
+    /**
+     * @Route("/posts/show/{id}", name="posts.show")
+     */
+    public function show($id)
+    {
+        $post = $this->getDoctrine()
+            ->getRepository(Post::class)
+            ->find($id);
+
+        return $this->render('post/show.html.twig', ['post' => $post]);
+    }
+}

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -11,7 +11,7 @@ use App\Entity\Post;
 class PostController extends Controller
 {
     /**
-     * @Route("/posts", name="posts")
+     * @Route("/posts", name="posts.index")
      */
     public function index()
     {

--- a/src/Controller/PostController.php
+++ b/src/Controller/PostController.php
@@ -2,11 +2,9 @@
 
 namespace App\Controller;
 
+use App\Entity\Post;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Response;
-
-use App\Entity\Post;
 
 class PostController extends Controller
 {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -7,17 +7,15 @@
         {% block stylesheets %}{% endblock %}
     </head>
     <body>
-
-    <div class="container-fluid">
         {% include 'partials/navbar.html.twig' %}
 
-        {% block body %}{% endblock %}
+        <div class="container">
+            {% block body %}{% endblock %}
         </div>
-
             {% block javascripts %}
-            <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-            <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
-        {% endblock %}
+                <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+                <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+                <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta.3/js/bootstrap.min.js" integrity="sha384-a5N7Y/aK3qNeh15eJKGWxsqtnX/wWdSZSKp+81YjTmS15nvnvxKHuzaWwXHDli+4" crossorigin="anonymous"></script>
+            {% endblock %}
     </body>
 </html>

--- a/templates/partials/navbar.html.twig
+++ b/templates/partials/navbar.html.twig
@@ -2,7 +2,7 @@
     <a class="navbar-brand" href="/">Intranet</a>
     <div class="navbar-nav">
         <a class="nav-item nav-link active" href="/">Home <span class="sr-only">(current)</span></a>
-        <a class="nav-item nav-link" href="/posts">Posts </a>
+        <a class="nav-item nav-link" href={{ url('posts.index') }}>Posts </a>
 
     </div>
     <div class="ml-auto">

--- a/templates/partials/navbar.html.twig
+++ b/templates/partials/navbar.html.twig
@@ -1,6 +1,10 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <a class="navbar-brand" href="/">Intranet</a>
+    <div class="navbar-nav">
+        <a class="nav-item nav-link active" href="/">Home <span class="sr-only">(current)</span></a>
+        <a class="nav-item nav-link" href="/posts">Posts </a>
 
+    </div>
     <div class="ml-auto">
         {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
             <span class="navbar-text">Hello {{ app.user.username }}</span>

--- a/templates/post/index.html.twig
+++ b/templates/post/index.html.twig
@@ -1,0 +1,30 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+
+    <div class="container">
+
+    {% if posts %}
+
+        {% for post in posts %}
+            <div class="card">
+                <div class="card-header">
+                    {{ post.author }} ({{ post.createdAt|date("Y-m-d H:i") }})
+                </div>
+                <div class="card-body">
+                    <h5 class="card-title">{{ post.title }}</h5>
+                    <p class="card-text">{{ post.content }}</p>
+                    <a href="{{ url('posts.show', {'id': post.id}) }}" class="btn btn-primary">More</a>
+                </div>
+            </div>
+            <br>
+        {% endfor %}
+
+    {% else %}
+
+        There is no post to show! :(
+
+    {% endif %}
+
+    </div>
+{% endblock %}

--- a/templates/post/show.html.twig
+++ b/templates/post/show.html.twig
@@ -1,0 +1,19 @@
+{% extends 'base.html.twig' %}
+
+{% block body %}
+
+    {% if post %}
+    <div class="card">
+        <div class="card-header">
+            {{ post.author }} ({{ post.createdAt|date("Y-m-d H:i") }})
+        </div>
+        <div class="card-body">
+            <h5 class="card-title">{{ post.title }}</h5>
+            <p class="card-text">{{ post.content }}</p>
+
+        </div>
+    </div>
+    <br>
+    {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Add basic scaffolding for posts.
It includes PostController with two actions: index (for all posts) and show (for single post).
Also, creates two new templates.

Test:
Make sure fixtures were loaded (you have posts in database)
Go to homepage, click on posts (expect list of posts), click on one of them on button "more" (expect single post on separate route)
If there are no posts to show - expect to see message "no posts to show :("

