### PR TITLE
Issue #36 [Bulletin Board] - Define what Post Filtering should do

### DIFF
--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -4,8 +4,14 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
-use Doctrine\ORM\EntityRepository;
+use App\Entity\Post;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Symfony\Bridge\Doctrine\RegistryInterface;
 
-class PostRepository extends EntityRepository
+class PostRepository extends ServiceEntityRepository
 {
+    public function __construct(RegistryInterface $registry)
+    {
+        parent::__construct($registry, Post::class);
+    }
 }

--- a/src/Service/PostFiltering.php
+++ b/src/Service/PostFiltering.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Repository\PostRepository;
+
+class PostFiltering
+{
+    /**
+     * @var \App\Repository\PostRepository
+     */
+    private $postRepository;
+
+    public function __construct(PostRepository $postRepository)
+    {
+        $this->postRepository = $postRepository;
+    }
+
+    public function find(WebFilter $filter)
+    {
+        $queryBuilder = $this->postRepository->createQueryBuilder('p');
+
+        if (null !== $filter->getCategory()) {
+            $queryBuilder->where('p.category = :category')->setParameter('category', $filter->getCategory());
+        }
+
+        $queryBuilder->setMaxResults($filter->getLimit());
+
+        return $queryBuilder->getQuery()->getResult();
+    }
+}

--- a/src/Service/WebFilter.php
+++ b/src/Service/WebFilter.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class WebFilter
+{
+    /** @var int */
+    private $category;
+
+    /** @var int */
+    private $limit;
+
+    /**
+     * WebFilter constructor.
+     *
+     * Currently we only allow 10, 20, or 30 results per page when fetching items from database
+     *
+     * @param int|null $category
+     * @param int|null $limit
+     */
+    public function __construct(?int $category, ?int $limit)
+    {
+        $this->category = $category;
+
+        if (!in_array($limit, [10, 20, 30])) {
+            $this->limit = 10;
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getCategory(): ?int
+    {
+        return $this->category;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+}


### PR DESCRIPTION
Posts can be filtered based on various criteria, so I've introduced a Filter object that represents various criteria (although at the moment we can only filter based on Category).

Actual filtering is being done by Doctrine's Query Builder, which takes the Filter as an argument, and builds the query based on data encapsulated in the Filter.

Closes #36 