### PR TITLE
Issue #35 [Bulletin Board] - Add Reference to Users from Posts

### DIFF
--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -43,9 +43,9 @@ class Post
     private $createdAt;
 
     /**
-     * @ORM\Column(type="string", length=50, nullable=false)
+     * @ORM\ManyToOne(targetEntity="User", inversedBy="posts")
      *
-     * @var string
+     * @var User
      */
     private $author;
 
@@ -69,10 +69,10 @@ class Post
      * @param string    $title
      * @param string    $content
      * @param \DateTime $createdAt
-     * @param string    $author
+     * @param User      $author
      * @param Category  $category
      */
-    public function __construct(int $id, string $title, string $content, \DateTime $createdAt, string $author, Category
+    public function __construct(int $id, string $title, string $content, \DateTime $createdAt, User $author, Category
     $category)
     {
         $this->id        = $id;
@@ -120,7 +120,7 @@ class Post
     /**
      * @return string
      */
-    public function getAuthor(): string
+    public function getAuthor(): User
     {
         return $this->author;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -28,6 +28,12 @@ class User extends BaseUser
     private $comments;
 
     /**
+     * @var ArrayCollection
+     * @ORM\OneToMany(targetEntity="App\Entity\Post", mappedBy="author")
+     */
+    private $posts;
+
+    /**
      * @var bool
      */
     private $administrator;
@@ -38,6 +44,7 @@ class User extends BaseUser
 
         $this->administrator = false;
         $this->comments      = new ArrayCollection();
+        $this->posts         = new ArrayCollection();
     }
 
     /**
@@ -46,6 +53,14 @@ class User extends BaseUser
     public function getComments(): ArrayCollection
     {
         return $this->comments;
+    }
+
+    /**
+     * @return \Doctrine\Common\Collections\ArrayCollection
+     */
+    public function getPosts(): ArrayCollection
+    {
+        return $this->posts;
     }
 
     /**

--- a/src/Migrations/Version20180207232942.php
+++ b/src/Migrations/Version20180207232942.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180207232942 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE posts ADD author_id INT DEFAULT NULL, DROP author');
+        $this->addSql('ALTER TABLE posts ADD CONSTRAINT FK_885DBAFAF675F31B FOREIGN KEY (author_id) REFERENCES users (id)');
+        $this->addSql('CREATE INDEX IDX_885DBAFAF675F31B ON posts (author_id)');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE posts DROP FOREIGN KEY FK_885DBAFAF675F31B');
+        $this->addSql('DROP INDEX IDX_885DBAFAF675F31B ON posts');
+        $this->addSql('ALTER TABLE posts ADD author VARCHAR(50) NOT NULL COLLATE utf8_unicode_ci, DROP author_id');
+    }
+}

--- a/tests/Entity/PostTest.php
+++ b/tests/Entity/PostTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Entity;
 use App\Entity\Category;
 use App\Entity\Post;
 use App\Entity\PostComment;
+use App\Entity\User;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 
@@ -33,7 +34,7 @@ class PostTest extends TestCase
         $this->title        = 'test post title';
         $this->content      = 'test post title';
         $this->createdAt    = new \DateTime('now');
-        $this->author       = 'Test Post Author';
+        $this->author       = Mockery::mock(User::class);
         $this->category     = Mockery::mock(Category::class);
         $this->post         = new Post($this->id, $this->title, $this->content, $this->createdAt, $this->author, $this->category);
     }


### PR DESCRIPTION
Post entity now has reference to User entity, which represents the
Post Author.

Tests have been updated to reflect the new state of entities.

Closes #35 