### PR TITLE
Issue #108 [Bulletin Board] - Fix fixtures for Post entity

### DIFF
--- a/src/DataFixtures/ORM/PostsFixtures.php
+++ b/src/DataFixtures/ORM/PostsFixtures.php
@@ -13,13 +13,15 @@ class PostsFixtures extends AbstractFixture implements OrderedFixtureInterface
 {
     public function load(ObjectManager $manager)
     {
+        $CEO = $this->getReference('user-admin');
+
         $declarations    = $this->getReference('category-declarations');
         $businessReports = $this->getReference('category-business-reports');
 
-        $declarationPost = new Post(1234, 'We\'re starting a company', 'Because we\'re cool!', new \DateTime('now'), 'CEO To Be',
+        $declarationPost = new Post(1234, 'We\'re starting a company', 'Because we\'re cool!', new \DateTime('now'), $CEO,
         $declarations);
 
-        $businessReportPost = new Post(4321, 'We\'re rich!', 'Because we have a clearly superior product, ...', new \DateTime('now'), 'CEO', $businessReports);
+        $businessReportPost = new Post(4321, 'We\'re rich!', 'Because we have a clearly superior product, ...', new \DateTime('now'), $CEO, $businessReports);
 
         $manager->persist($declarationPost);
         $manager->persist($businessReportPost);


### PR DESCRIPTION
PR #103 created a bit of a mess - I forgot to update the data fixtures
for Post entity.
Post was expecting to receive an instance of a User object, but
fixtures were passing in the string.

This will load a user object and pass it into the Post's constructor.

Closes #108 