### PR TITLE
Add phing

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+
+<project default="default" name="Team 1 Internals">
+
+    <target name="default" description="Help target">
+        <exec command="phing -l" passthru="true"/>
+    </target>
+
+    <target name="all" depends="test,fix-codestandards,phpstan"/>
+    <target name="test" depends="phpunit"/>
+
+    <target name="fix-codestandards" depends="phpcbf,php-cs-fixer-fix,phpmd,phpcs"/>
+    <target name="check-codestandards" depends="php-cs-fixer-check,phpmd,phpcs"/>
+
+    <target name="php-cs-fixer-fix" description="Run php-cs-fixer fix">
+        <retry retrycount="3">
+            <exec command="./vendor/bin/php-cs-fixer fix" passthru="true" checkreturn="true"/>
+        </retry>
+    </target>
+
+    <target name="phpunit" description="Run phpunit">
+        <exec command="./vendor/bin/simple-phpunit" passthru="true" checkreturn="true"/>
+    </target>
+
+    <target name="phpstan" description="Run phpstan">
+        <exec command="./vendor/bin/phpstan --memory-limit=-1 analyse -l 7 -c phpstan.neon src tests" passthru="true" checkreturn="true"/>
+    </target>
+
+    <target name="php-cs-fixer-check" description="Run php-cs-fixer check">
+        <exec command="./vendor/bin/php-cs-fixer fix --dry-run --diff" passthru="true" checkreturn="true"/>
+    </target>
+
+    <target name="phpmd" description="Run phpmd">
+        <phingcall target="phpmd-task">
+            <property name="path" value="src"/>
+        </phingcall>
+        <phingcall target="phpmd-task">
+            <property name="path" value="tests"/>
+        </phingcall>
+    </target>
+
+    <target name="phpcs" description="Run phpcs">
+        <phingcall target="phpcs-task">
+            <property name="path" value="src"/>
+        </phingcall>
+        <phingcall target="phpcs-task">
+            <property name="path" value="tests"/>
+        </phingcall>
+    </target>
+
+    <target name="phpcbf" description="Run phpcbf">
+        <phingcall target="phpcbf-task">
+            <property name="path" value="src"/>
+        </phingcall>
+        <phingcall target="phpcbf-task">
+            <property name="path" value="tests"/>
+        </phingcall>
+    </target>
+
+    <target name="phpmd-task" description="Run php mess detector">
+        <exec command="./vendor/bin/phpmd ${path} text phpmd.xml" passthru="true" checkreturn="true"/>
+    </target>
+    <target name="phpcs-task" description="Run php code sniffer">
+        <exec command="./vendor/bin/phpcs --standard=phpcs.xml ${path} -n" passthru="true" checkreturn="true"/>
+    </target>
+    <target name="phpcbf-task" description="Run php code sniffer fixer">
+        <exec command="./vendor/bin/phpcbf --standard=phpcs.xml ${path} -n" passthru="true" checkreturn="true"/>
+    </target>
+
+    <target name="refresh-dev-db" description="Refresh dev DB">
+        <exec command="bin/console doctrine:database:drop --force --if-exists --env=dev" passthru="true" checkreturn="true"/>
+        <exec command="bin/console doctrine:database:create --env=dev" passthru="true" checkreturn="true"/>
+        <exec command="bin/console doctrine:migrations:migrate --no-interaction --env=dev" passthru="true"/>
+        <exec command="bin/console doctrine:fixtures:load --verbose --append --env=dev" passthru="true"/>
+    </target>
+
+    <target name="refresh-test-db" description="Refresh test DB">
+        <exec command="bin/console doctrine:database:drop --force --if-exists --env=test" passthru="true" checkreturn="true"/>
+        <exec command="bin/console doctrine:database:create --env=test" passthru="true" checkreturn="true"/>
+        <exec command="bin/console doctrine:migrations:migrate --no-interaction --env=test" passthru="true"/>
+        <exec command="bin/console doctrine:fixtures:load --verbose --append --env=test" passthru="true"/>
+    </target>
+
+</project>

--- a/circle.yml
+++ b/circle.yml
@@ -60,7 +60,7 @@ jobs:
           
       - run:
           name: PHPMD
-          command: vendor/bin/phpmd src/ text phpmd.xml
+          command: vendor/bin/phing phpmd
 
       - run:
           name: PHP Code Sniffer

--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ jobs:
 
       - run:
           name: Php-cs-fixer
-          command: php vendor/bin/php-cs-fixer fix --dry-run --diff
+          command: vendor/bin/phing php-cs-fixer-check
 
       - run:
           name: Ship codecoverage to codecov.io

--- a/circle.yml
+++ b/circle.yml
@@ -63,13 +63,9 @@ jobs:
           command: vendor/bin/phpmd src/ text phpmd.xml
 
       - run:
-          name: PHP Code Sniffer on src
-          command: vendor/bin/phpcs --standard=phpcs.xml src -n
+          name: PHP Code Sniffer
+          command: vendor/bin/phing phpcs
 
-      - run:
-          name: PHP Code Sniffer on tests
-          command: vendor/bin/phpcs --standard=phpcs.xml tests -n
-          
       - save_cache:
           key: cache-v1-{{ checksum "composer.lock" }}
           paths:

--- a/circle.yml
+++ b/circle.yml
@@ -48,7 +48,7 @@ jobs:
 
       - run:
           name: PHPUnit
-          command: ./vendor/bin/simple-phpunit
+          command: vendor/bin/phing phpunit
 
       - run:
           name: Php-cs-fixer

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.0",
         "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
+        "phing/phing": "^2.16",
         "phpmd/phpmd": "^2.6",
         "phpstan/phpstan": "^0.9.2",
         "squizlabs/php_codesniffer": "^3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c058a57499813193d372fdb1d69580b0",
+    "content-hash": "fa41b0c0c05a4acbae8a0602cfafb9d7",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -5755,6 +5755,99 @@
             ],
             "description": "Official version of pdepend to be handled with Composer",
             "time": "2017-12-13T13:21:38+00:00"
+        },
+        {
+            "name": "phing/phing",
+            "version": "2.16.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phingofficial/phing.git",
+                "reference": "cbe0f969e434e269af91b4160b86fe899c6e07c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/cbe0f969e434e269af91b4160b86fe899c6e07c7",
+                "reference": "cbe0f969e434e269af91b4160b86fe899c6e07c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0",
+                "symfony/yaml": "^3.1 || ^4.0"
+            },
+            "require-dev": {
+                "ext-pdo_sqlite": "*",
+                "mikey179/vfsstream": "^1.6",
+                "pdepend/pdepend": "2.x",
+                "pear/archive_tar": "1.4.x",
+                "pear/http_request2": "dev-trunk",
+                "pear/net_growl": "dev-trunk",
+                "pear/pear-core-minimal": "1.10.1",
+                "pear/versioncontrol_git": "@dev",
+                "pear/versioncontrol_svn": "~0.5",
+                "phpdocumentor/phpdocumentor": "2.x",
+                "phploc/phploc": "~2.0.6",
+                "phpmd/phpmd": "~2.2",
+                "phpunit/phpunit": ">=3.7",
+                "sebastian/git": "~1.0",
+                "sebastian/phpcpd": "2.x",
+                "siad007/versioncontrol_hg": "^1.0",
+                "simpletest/simpletest": "^1.1",
+                "squizlabs/php_codesniffer": "~2.2"
+            },
+            "suggest": {
+                "pdepend/pdepend": "PHP version of JDepend",
+                "pear/archive_tar": "Tar file management class",
+                "pear/versioncontrol_git": "A library that provides OO interface to handle Git repository",
+                "pear/versioncontrol_svn": "A simple OO-style interface for Subversion, the free/open-source version control system",
+                "phpdocumentor/phpdocumentor": "Documentation Generator for PHP",
+                "phploc/phploc": "A tool for quickly measuring the size of a PHP project",
+                "phpmd/phpmd": "PHP version of PMD tool",
+                "phpunit/php-code-coverage": "Library that provides collection, processing, and rendering functionality for PHP code coverage information",
+                "phpunit/phpunit": "The PHP Unit Testing Framework",
+                "sebastian/phpcpd": "Copy/Paste Detector (CPD) for PHP code",
+                "siad007/versioncontrol_hg": "A library for interfacing with Mercurial repositories.",
+                "tedivm/jshrink": "Javascript Minifier built in PHP"
+            },
+            "bin": [
+                "bin/phing"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.16.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "classes/phing/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "classes"
+            ],
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Michiel Rook",
+                    "email": "mrook@php.net"
+                },
+                {
+                    "name": "Phing Community",
+                    "homepage": "https://www.phing.info/trac/wiki/Development/Contributors"
+                }
+            ],
+            "description": "PHing Is Not GNU make; it's a PHP project build system or build tool based on Apache Ant.",
+            "homepage": "https://www.phing.info/",
+            "keywords": [
+                "build",
+                "phing",
+                "task",
+                "tool"
+            ],
+            "time": "2018-01-25T13:18:09+00:00"
         },
         {
             "name": "php-cs-fixer/diff",

--- a/symfony.lock
+++ b/symfony.lock
@@ -149,6 +149,9 @@
     "pdepend/pdepend": {
         "version": "2.5.2"
     },
+    "phing/phing": {
+        "version": "2.16.1"
+    },
     "php-cs-fixer/diff": {
         "version": "v1.2.0"
     },


### PR DESCRIPTION
In order to avoid remembering long CLI methods
Lets add phing
To ease up task definition

Idea is, instead of remembering all the options for CLI commands we can just run 

```
./vendor/bin/phing phpcs
```

if we want to refresh dev db, all we need is (instead of running 4 separate commands)

```
./vendor/bin/phing refresh-dev-db
```

Closes #138