### PR TITLE
Issuse #145 - Add missing entity property to db mapping

### DIFF
--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -79,9 +79,9 @@ class Post
 
     public function __construct()
     {
-        $this->archived   = false;
-        $this->active     = true;
-        $this->comments   = new ArrayCollection();
+        $this->archived = false;
+        $this->active   = true;
+        $this->comments = new ArrayCollection();
     }
 
     /**

--- a/src/Entity/PostComment.php
+++ b/src/Entity/PostComment.php
@@ -38,7 +38,9 @@ class PostComment
      */
     private $user;
 
-    /** @var \DateTime $timestamp */
+    /** @var \DateTime
+     * @ORM\Column(type="datetime", nullable=false)
+     */
     private $timestamp;
 
     public function __construct()

--- a/src/Migrations/Version20180224124429.php
+++ b/src/Migrations/Version20180224124429.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180224124429 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE post_comments ADD timestamp DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE post_comments DROP timestamp');
+    }
+}


### PR DESCRIPTION
PostComment didn't have it's timestamp property mapped to database.
I'm adding the doctrine annotation to entity's field and creating new migration file to add the field to database table. 

Closes #145 